### PR TITLE
1.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## V1.18
+### Script
+* bugfix: intermediate meter Shelly 1PM did not work
+* add: support Shelly 3EM Pro for powermeter and intermediate powermeter
+* add: support of Shelly 1PM & Shelly Plus 1PM
+### Config
+* add: `[SELECT_POWERMETER]`: `USE_SHELLY_3EM_PRO`
+* add: `[SELECT_INTERMEDIATE_METER]`: `USE_SHELLY_3EM_PRO_INTERMEDIATE`
+* add: `[SELECT_INTERMEDIATE_METER]`: `USE_SHELLY_PLUS_1PM_INTERMEDIATE`
+
 ## V1.17
 ### Script
 * add: support EMLOG System for powermeter and intermediate powermeter

--- a/HoymilesZeroExport_Config.ini
+++ b/HoymilesZeroExport_Config.ini
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 [VERSION]
-VERSION = 1.17
+VERSION = 1.18
 
 [SELECT_DTU]
 # --- define your DTU (only one) ---

--- a/HoymilesZeroExport_Config.ini
+++ b/HoymilesZeroExport_Config.ini
@@ -26,6 +26,7 @@ USE_OPENDTU = false
 # --- define your Powermeter (only one) ---
 USE_TASMOTA = true
 USE_SHELLY_3EM = false
+USE_SHELLY_3EM_PRO = false
 USE_SHRDZM = false
 USE_EMLOG = false
 
@@ -77,7 +78,9 @@ EMLOG_METERINDEX =
 # --- define your intermediate meter - if you don´t have one set the following defines to false to use the value from your DTU---
 USE_TASMOTA_INTERMEDIATE = false
 USE_SHELLY_3EM_INTERMEDIATE = false
+USE_SHELLY_3EM_PRO_INTERMEDIATE = false
 USE_SHELLY_1PM_INTERMEDIATE = false
+USE_SHELLY_PLUS_1PM_INTERMEDIATE = false
 USE_SHRDZM_INTERMEDIATE = false
 USE_EMLOG_INTERMEDIATE = false
 


### PR DESCRIPTION
## V1.18
### Script
* bugfix: intermediate meter Shelly 1PM did not work
* add: support Shelly 3EM Pro for powermeter and intermediate powermeter
* add: support of Shelly 1PM & Shelly Plus 1PM
### Config
* add: `[SELECT_POWERMETER]`: `USE_SHELLY_3EM_PRO`
* add: `[SELECT_INTERMEDIATE_METER]`: `USE_SHELLY_3EM_PRO_INTERMEDIATE`
* add: `[SELECT_INTERMEDIATE_METER]`: `USE_SHELLY_PLUS_1PM_INTERMEDIATE`