### PR TITLE
Add HomeAssistant, Bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## V1.30
+### Script
+* use different wait time for turning inverter off or on
+* add HOME ASSISTANT support
+### Config
+* add: `[COMMON]`: `SET_POWER_STATUS_DELAY_IN_SECONDS` - delay time after turning the inverter off or on
+* add: `[SELECT_POWERMETER]`: `USE_HOMEASSISTANT`
+* add: section `[HOMEASSISTANT]` + section `[INTERMEDIATE_HOMEASSISTANT]`
+* add: `[SELECT_INTERMEDIATE_METER]`: `USE_HOMEASSISTANT_INTERMEDIATE`
+
 ## V1.29
 ### Script
 * on Startup: initialize inverter with lowest limit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## V1.29
+### Script
+* on Startup: initialize inverter with lowest limit.
+* allow to send same Limits to inverter, use SET_LIMIT_RETRY to limit the repeats
+
 ## V1.28
 ### Script
 * add HOY_BATTERY_NORMAL_WATT: you can further limit the inverter in battery mode. E.g. if you have a 1500W Inverter you can limit the max. output power in battery mode to 750 Watts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## V1.32
+### Script
+* bugfix: cast to int
+
 ## V1.31
 ### Script
 * support of power-output-factor to compensate some Inverters (e.g. 700W Limit = 800W Output)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## V1.31
+### Script
+* support of power-output-factor to compensate some Inverters (e.g. 700W Limit = 800W Output)
+### Config
+* add: `[INVERTER_x]`: `HOY_COMPENSATE_WATT_FACTOR` - enter your Factor here. Eg: if you set a limit of 750W = 850W Output -> enter Factor 0.88
+
 ## V1.30
 ### Script
 * use different wait time for turning inverter off or on

--- a/HoymilesZeroExport.py
+++ b/HoymilesZeroExport.py
@@ -94,7 +94,7 @@ def SetLimit(pLimit):
                 SetLimit.LastLimit = pLimit
                 SetLimit.SameLimitCnt = 0
             if SetLimit.SameLimitCnt >= SET_LIMIT_RETRY:
-                logger.info("Set Limit Retry Counter exceeded: Inverterlimit already at %s Watt",int(pLimit))
+                logger.info("Retry Counter exceeded: Inverterlimit already at %s Watt",int(pLimit))
                 time.sleep(SET_LIMIT_DELAY_IN_SECONDS)
                 return
         logger.info("setting new limit to %s Watt",int(pLimit))
@@ -291,7 +291,10 @@ def SetHoymilesPowerStatus(pInverterId, pActive):
                 SetLimit.LastPowerStatus[pInverterId] = pActive
                 SetLimit.SamePowerStatusCnt[pInverterId] = 0
             if SetLimit.SamePowerStatusCnt[pInverterId] >= SET_LIMIT_RETRY:
-                logger.info("Set Limit Retry Counter exceeded: Inverter PowerStatus already %s",int(pActive))
+                if pActive:
+                    logger.info("Retry Counter exceeded: Inverter PowerStatus already ON")
+                else:
+                    logger.info("Retry Counter exceeded: Inverter PowerStatus already OFF")
                 time.sleep(SET_LIMIT_DELAY_IN_SECONDS)
                 return
         if USE_AHOY:

--- a/HoymilesZeroExport.py
+++ b/HoymilesZeroExport.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = "Tobias Kraft"
-__version__ = "1.31"
+__version__ = "1.32"
 
 import requests
 import time
@@ -108,7 +108,7 @@ def SetLimit(pLimit):
             NewLimit = ApplyLimitsToSetpointInverter(i, NewLimit)
             if HOY_COMPENSATE_WATT_FACTOR[i] != 1:
                 logger.info('Ahoy: Inverter "%s": compensate Limit from %s Watt to %s Watt', NAME[i], int(NewLimit), int(NewLimit*HOY_COMPENSATE_WATT_FACTOR[i]))
-                NewLimit = NewLimit * HOY_COMPENSATE_WATT_FACTOR[i]
+                NewLimit = int(NewLimit * HOY_COMPENSATE_WATT_FACTOR[i])
                 NewLimit = ApplyLimitsToMaxInverterLimits(i, NewLimit)
             if USE_AHOY:
                 SetLimitAhoy(i, NewLimit)

--- a/HoymilesZeroExport.py
+++ b/HoymilesZeroExport.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = "Tobias Kraft"
-__version__ = "1.28"
+__version__ = "1.29"
 
 import requests
 import time
@@ -727,7 +727,8 @@ try:
     if GetHoymilesAvailable():
         for i in range(INVERTER_COUNT):
             SetHoymilesPowerStatus(i, True)
-        newLimitSetpoint = GetMaxWattFromAllInverters()
+        GetCheckBattery()
+        newLimitSetpoint = GetMinWattFromAllInverters()
         GetHoymilesActualPower()
         SetLimit(newLimitSetpoint)
     GetPowermeterWatts()
@@ -804,8 +805,7 @@ while True:
             # check for upper and lower limits
             newLimitSetpoint = ApplyLimitsToSetpoint(newLimitSetpoint)
             # set new limit to inverter
-            if newLimitSetpoint != PreviousLimitSetpoint:
-                SetLimit(newLimitSetpoint)
+            SetLimit(newLimitSetpoint)
         else:
             if hasattr(SetLimit, "LastLimit"):
                 SetLimit.LastLimit = -1

--- a/HoymilesZeroExport_Config.ini
+++ b/HoymilesZeroExport_Config.ini
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 [VERSION]
-VERSION = 1.28
+VERSION = 1.30
 
 [SELECT_DTU]
 # --- define your DTU (only one) ---
@@ -30,6 +30,7 @@ USE_SHELLY_3EM_PRO = false
 USE_SHRDZM = false
 USE_EMLOG = false
 USE_IOBROKER = false
+USE_HOMEASSISTANT = false
 
 [AHOY_DTU]
 # --- defines for AHOY-DTU ---
@@ -87,6 +88,19 @@ IOBROKER_POWER_INPUT_ALIAS = alias.0.Zaehler.Zaehler_CurrentInputWatt
 # Power-MQTT output label (negative active instantaneous power, e.g. OBIS Code 2.7.0)
 IOBROKER_POWER_OUTPUT_ALIAS = alias.0.Zaehler.Zaehler_CurrentOutputWatt
 
+[HOMEASSISTANT]
+# --- defines for HOME ASSISTANT (you need to create a Long-Lived Access Token in your profile) ---
+HA_IP = xxx.xxx.xxx.xxx
+HA_PORT = 8123
+HA_ACCESSTOKEN = xxx
+HA_CURRENT_POWER_ENTITY = sensor.dtz541_sml_curr_w
+# if your powermeter does NOT output the current power: you need to calculate it -> Power(W) = OBIS(1.7.0) - OBIS(2.7.0)
+HA_POWER_CALCULATE = FALSE
+# Power-MQTT Input label (positive active instantaneous power, e.g. OBIS Code 1.7.0)
+HA_POWER_INPUT_ALIAS = sensor.dtz541_sml_170
+# Power-MQTT output label (negative active instantaneous power, e.g. OBIS Code 2.7.0)
+HA_POWER_OUTPUT_ALIAS = sensor.dtz541_sml_270
+
 [SELECT_INTERMEDIATE_METER]
 # if you have an intermediate meter to measure the outputpower of your inverter you can set it here. It is faster than the DTU current_power value
 # --- define your intermediate meter - if you don´t have one set the following defines to false to use the value from your DTU---
@@ -98,6 +112,7 @@ USE_SHELLY_PLUS_1PM_INTERMEDIATE = false
 USE_SHRDZM_INTERMEDIATE = false
 USE_EMLOG_INTERMEDIATE = false
 USE_IOBROKER_INTERMEDIATE = false
+USE_HOMEASSISTANT_INTERMEDIATE = false
 
 [INTERMEDIATE_TASMOTA]
 # --- defines for Tasmota Smartmeter Modul---
@@ -131,6 +146,13 @@ IOBROKER_IP_INTERMEDIATE = xxx.xxx.xxx.xxx
 IOBROKER_PORT_INTERMEDIATE = 8087
 IOBROKER_CURRENT_POWER_ALIAS_INTERMEDIATE = alias.0.Zaehler.Zaehler_SolarCurrentWatt
 
+[INTERMEDIATE_HOMEASSISTANT]
+# --- defines for HOME ASSISTANT (you need to create a Long-Lived Access Token in your profile) ---
+HA_IP_INTERMEDIATE = xxx.xxx.xxx.xxx
+HA_PORT_INTERMEDIATE = 8123
+HA_ACCESSTOKEN_INTERMEDIATE = xxx
+HA_CURRENT_POWER_ENTITY_INTERMEDIATE = sensor.dtz541_sml_curr_w
+
 [COMMON]
 # Number of Inverters
 INVERTER_COUNT = 1
@@ -158,6 +180,8 @@ LOG_BACKUP_COUNT = 30
 SET_LIMIT_RETRY = 10
 # log the inverter temperature
 LOG_TEMPERATURE = false
+# delay time after turning the inverter off or on
+SET_POWER_STATUS_DELAY_IN_SECONDS = 10
 
 [CONTROL]
 # --- global defines for control behaviour ---

--- a/HoymilesZeroExport_Config.ini
+++ b/HoymilesZeroExport_Config.ini
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 [VERSION]
-VERSION = 1.30
+VERSION = 1.31
 
 [SELECT_DTU]
 # --- define your DTU (only one) ---
@@ -198,6 +198,8 @@ POWERMETER_MAX_POINT = 0
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
 HOY_MIN_WATT_IN_PERCENT = 5
+# factor to multiply before set Limit. Some Inverters have some offsets, with that factor you can compensate it. Default = 1
+HOY_COMPENSATE_WATT_FACTOR = 1
 # battery powered?
 HOY_BATTERY_MODE = false
 # voltage to turn off the inverter

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This script does not use MQTT, it's based on webapi communication.
 - [SHRDZM Smartmeter Modul](https://cms.shrdzm.com/produkt/smartmeter-modul/)
 - [Emlog ("electronic meter log")](https://weidmann-elektronik.de/Emlog_Projekt.html)
 - [ioBroker](https://www.iobroker.net/) with [simpleAPI](https://github.com/ioBroker/ioBroker.simple-api)
+- [HomeAssistant](https://www.home-assistant.io/)
 - easy to implement new smart meter modules supporting WebAPI / JSON
 
 ### Supported DTU and Inverters


### PR DESCRIPTION
integrate:

## V1.32
### Script
* bugfix: cast to int

## V1.31
### Script
* support of power-output-factor to compensate some Inverters (e.g. 700W Limit = 800W Output)
### Config
* add: `[INVERTER_x]`: `HOY_COMPENSATE_WATT_FACTOR` - enter your Factor here. Eg: if you set a limit of 750W = 850W Output -> enter Factor 0.88

## V1.30
### Script
* use different wait time for turning inverter off or on
* add HOME ASSISTANT support
### Config
* add: `[COMMON]`: `SET_POWER_STATUS_DELAY_IN_SECONDS` - delay time after turning the inverter off or on
* add: `[SELECT_POWERMETER]`: `USE_HOMEASSISTANT`
* add: section `[HOMEASSISTANT]` + section `[INTERMEDIATE_HOMEASSISTANT]`
* add: `[SELECT_INTERMEDIATE_METER]`: `USE_HOMEASSISTANT_INTERMEDIATE`

## V1.29
### Script
* on Startup: initialize inverter with lowest limit.
* allow to send same Limits to inverter, use SET_LIMIT_RETRY to limit the repeats