### PR TITLE
Improve Battery Mode, Jump Limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## V1.45
+### script
+* BatteryMode: save latest five PanelMinVoltages and return the highest value of them. This ignores temporarly DTU-Errors (e.g. reset values at midnight) for maximum of five iterations.
+
 ## V1.44
 ### script
 * replaced the feature "jump to max limit" to "jump to defined limit"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## V1.44
+### script
+* replaced the feature "jump to max limit" to "jump to defined limit"
+### Config
+* changed `[COMMON]/JUMP_TO_MAX_LIMIT_ON_GRID_USAGE` to `[COMMON]/ON_GRID_USAGE_JUMP_TO_LIMIT_PERCENT`
+
 ## V1.43
 ### script
 * Bugfix: timeout OpenDTU

--- a/HoymilesZeroExport_Config.ini
+++ b/HoymilesZeroExport_Config.ini
@@ -19,7 +19,7 @@
 # ---------------------------------------------------------------------
 
 [VERSION]
-VERSION = 1.40
+VERSION = 1.44
 
 [SELECT_DTU]
 # --- define your DTU (only one) ---
@@ -181,9 +181,9 @@ SET_LIMIT_DELAY_IN_SECONDS = 5
 SET_LIMIT_DELAY_IN_SECONDS_MULTIPLE_INVERTER = 2
 # polling interval for powermeter (must be < LOOP_INTERVAL_IN_SECONDS)
 POLL_INTERVAL_IN_SECONDS = 1
-# when powermeter > POWERMETER_MAX_POINT: (True): immediatelly jump to HOY_MAX_WATT of inverter; (False): increase limit based on previous limit
-# if you are on battery mode, recommend setting is "false"
-JUMP_TO_MAX_LIMIT_ON_GRID_USAGE = true
+# if your powermeter exceeds POWERMETER_MAX_POINT: immediatelly set the limit to predefined percent of HOY_MAX_WATT (if you have more than one inverter it´s the sum of all HOY_MAX_WATT)
+# value = 0 disables the feature. Values are possible from [0 to 100]
+ON_GRID_USAGE_JUMP_TO_LIMIT_PERCENT = 100
 # max difference between Limit and real output power in % of HOY_MAX_WATT (100 = disabled)
 MAX_DIFFERENCE_BETWEEN_LIMIT_AND_OUTPUTPOWER = 100
 # enable logging to file


### PR DESCRIPTION
## V1.45
### script
* BatteryMode: save latest five PanelMinVoltages and return the highest value of them. This ignores temporarly DTU-Errors (e.g. reset values at midnight) for maximum of five iterations.

## V1.44
### script
* replaced the feature "jump to max limit" to "jump to defined limit"
### Config
* changed `[COMMON]/JUMP_TO_MAX_LIMIT_ON_GRID_USAGE` to `[COMMON]/ON_GRID_USAGE_JUMP_TO_LIMIT_PERCENT`