### PR TITLE
add support for powermeter vzlogger local http api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## V1.47
+### script
+* Add VZLogger local http api support (https://wiki.volkszaehler.org/software/controller/vzlogger/vzlogger_conf_parameter#local)
+### Config
+* add: `[SELECT_POWERMETER]`: `USE_VZLOGGER`
+* add: `[SELECT_INTERMEDIATE_METER]`: `USE_VZLOGGER_INTERMEDIATE`
+* add: `[VZLOGGER]`: `VZL_IP`
+* add: `[VZLOGGER]`: `VZL_PORT`
+* add: `[VZLOGGER]`: `VZL_UUID`
+* add: `[INTERMEDIATE_VZLOGGER]`: `VZL_IP_INTERMEDIATE`
+* add: `[INTERMEDIATE_VZLOGGER]`: `VZL_PORT_INTERMEDIATE`
+* add: `[INTERMEDIATE_VZLOGGER]`: `VZL_UUID_INTERMEDIATE`
+
 ## V1.46
 ### script
 * Bugfix: jump to defined limit never increased if < 100%

--- a/HoymilesZeroExport.py
+++ b/HoymilesZeroExport.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = "Tobias Kraft"
-__version__ = "1.46"
+__version__ = "1.47"
 
 import requests
 import time
@@ -459,6 +459,8 @@ def GetHoymilesActualPower():
             return GetPowermeterWattsIobroker_Intermediate()
         elif USE_HOMEASSISTANT_INTERMEDIATE:
             return GetPowermeterWattsHomeAssistant_Intermediate()
+        elif USE_VZLOGGER_INTERMEDIATE:
+            return GetPowermeterWattsVZLogger_Intermediate()
         elif USE_AHOY:
             for i in range(INVERTER_COUNT):
                 if (not AVAILABLE[i]) or (not HOY_POWER_STATUS[i]):
@@ -553,6 +555,13 @@ def GetPowermeterWattsHomeAssistant_Intermediate():
     logger.info("intermediate meter HomeAssistant: %s %s",Watts," Watt")
     return CastToInt(Watts)
 
+def GetPowermeterWattsVZLogger_Intermediate():
+    url = f"http://{VZL_IP_INTERMEDIATE}:{VZL_PORT_INTERMEDIATE}/{VZL_UUID_INTERMEDIATE}"
+    ParsedData = requests.get(url, timeout=10).json()
+    Watts = CastToInt(ParsedData['data'][0]['tuples'][0][1])
+    logger.info("powermeter VZLogger: %s %s",Watts," Watt")
+    return CastToInt(Watts)
+
 def GetPowermeterWattsTasmota():
     url = f'http://{TASMOTA_IP}/cm?cmnd=status%2010'
     ParsedData = requests.get(url, timeout=10).json()
@@ -642,6 +651,13 @@ def GetPowermeterWattsHomeAssistant():
     logger.info("powermeter HomeAssistant: %s %s",Watts," Watt")
     return CastToInt(Watts)
 
+def GetPowermeterWattsVZLogger():
+    url = f"http://{VZL_IP}:{VZL_PORT}/{VZL_UUID}"
+    ParsedData = requests.get(url, timeout=10).json()
+    Watts = CastToInt(ParsedData['data'][0]['tuples'][0][1])
+    logger.info("powermeter VZLogger: %s %s",Watts," Watt")
+    return CastToInt(Watts)
+
 def GetPowermeterWatts():
     try:
         if USE_SHELLY_EM:
@@ -660,6 +676,8 @@ def GetPowermeterWatts():
             return GetPowermeterWattsIobroker()
         elif USE_HOMEASSISTANT:
             return GetPowermeterWattsHomeAssistant()
+        elif USE_VZLOGGER:
+            return GetPowermeterWattsVZLogger()
         else:
             raise Exception("Error: no powermeter defined!")
     except:
@@ -740,6 +758,7 @@ USE_SHRDZM = config.getboolean('SELECT_POWERMETER', 'USE_SHRDZM')
 USE_EMLOG = config.getboolean('SELECT_POWERMETER', 'USE_EMLOG')
 USE_IOBROKER = config.getboolean('SELECT_POWERMETER', 'USE_IOBROKER')
 USE_HOMEASSISTANT = config.getboolean('SELECT_POWERMETER', 'USE_HOMEASSISTANT')
+USE_VZLOGGER = config.getboolean('SELECT_POWERMETER', 'USE_VZLOGGER')
 AHOY_IP = config.get('AHOY_DTU', 'AHOY_IP')
 OPENDTU_IP = config.get('OPEN_DTU', 'OPENDTU_IP')
 OPENDTU_USER = config.get('OPEN_DTU', 'OPENDTU_USER')
@@ -772,6 +791,9 @@ HA_CURRENT_POWER_ENTITY = config.get('HOMEASSISTANT', 'HA_CURRENT_POWER_ENTITY')
 HA_POWER_CALCULATE = config.getboolean('HOMEASSISTANT', 'HA_POWER_CALCULATE')
 HA_POWER_INPUT_ALIAS = config.get('HOMEASSISTANT', 'HA_POWER_INPUT_ALIAS')
 HA_POWER_OUTPUT_ALIAS = config.get('HOMEASSISTANT', 'HA_POWER_OUTPUT_ALIAS')
+VZL_IP = config.get('VZLOGGER', 'VZL_IP')
+VZL_PORT = config.get('VZLOGGER', 'VZL_PORT')
+VZL_UUID = config.get('VZLOGGER', 'VZL_UUID')
 USE_TASMOTA_INTERMEDIATE = config.getboolean('SELECT_INTERMEDIATE_METER', 'USE_TASMOTA_INTERMEDIATE')
 USE_SHELLY_EM_INTERMEDIATE = config.getboolean('SELECT_INTERMEDIATE_METER', 'USE_SHELLY_EM_INTERMEDIATE')
 USE_SHELLY_3EM_INTERMEDIATE = config.getboolean('SELECT_INTERMEDIATE_METER', 'USE_SHELLY_3EM_INTERMEDIATE')
@@ -782,6 +804,7 @@ USE_SHRDZM_INTERMEDIATE = config.getboolean('SELECT_INTERMEDIATE_METER', 'USE_SH
 USE_EMLOG_INTERMEDIATE = config.getboolean('SELECT_INTERMEDIATE_METER', 'USE_EMLOG_INTERMEDIATE')
 USE_IOBROKER_INTERMEDIATE = config.getboolean('SELECT_INTERMEDIATE_METER', 'USE_IOBROKER_INTERMEDIATE')
 USE_HOMEASSISTANT_INTERMEDIATE = config.getboolean('SELECT_INTERMEDIATE_METER', 'USE_HOMEASSISTANT_INTERMEDIATE')
+USE_VZLOGGER_INTERMEDIATE = config.getboolean('SELECT_INTERMEDIATE_METER', 'USE_VZLOGGER_INTERMEDIATE')
 TASMOTA_IP_INTERMEDIATE = config.get('INTERMEDIATE_TASMOTA', 'TASMOTA_IP_INTERMEDIATE')
 TASMOTA_JSON_STATUS_INTERMEDIATE = config.get('INTERMEDIATE_TASMOTA', 'TASMOTA_JSON_STATUS_INTERMEDIATE')
 TASMOTA_JSON_PAYLOAD_MQTT_PREFIX_INTERMEDIATE = config.get('INTERMEDIATE_TASMOTA', 'TASMOTA_JSON_PAYLOAD_MQTT_PREFIX_INTERMEDIATE')
@@ -801,6 +824,9 @@ HA_IP_INTERMEDIATE = config.get('INTERMEDIATE_HOMEASSISTANT', 'HA_IP_INTERMEDIAT
 HA_PORT_INTERMEDIATE = config.get('INTERMEDIATE_HOMEASSISTANT', 'HA_PORT_INTERMEDIATE')
 HA_ACCESSTOKEN_INTERMEDIATE = config.get('INTERMEDIATE_HOMEASSISTANT', 'HA_ACCESSTOKEN_INTERMEDIATE')
 HA_CURRENT_POWER_ENTITY_INTERMEDIATE = config.get('INTERMEDIATE_HOMEASSISTANT', 'HA_CURRENT_POWER_ENTITY_INTERMEDIATE')
+VZL_IP_INTERMEDIATE = config.get('INTERMEDIATE_VZLOGGER', 'VZL_IP_INTERMEDIATE')
+VZL_PORT_INTERMEDIATE = config.get('INTERMEDIATE_VZLOGGER', 'VZL_PORT_INTERMEDIATE')
+VZL_UUID_INTERMEDIATE = config.get('INTERMEDIATE_VZLOGGER', 'VZL_UUID_INTERMEDIATE')
 INVERTER_COUNT = config.getint('COMMON', 'INVERTER_COUNT')
 LOOP_INTERVAL_IN_SECONDS = config.getint('COMMON', 'LOOP_INTERVAL_IN_SECONDS')
 SET_LIMIT_DELAY_IN_SECONDS = config.getint('COMMON', 'SET_LIMIT_DELAY_IN_SECONDS')

--- a/HoymilesZeroExport.py
+++ b/HoymilesZeroExport.py
@@ -559,7 +559,7 @@ def GetPowermeterWattsVZLogger_Intermediate():
     url = f"http://{VZL_IP_INTERMEDIATE}:{VZL_PORT_INTERMEDIATE}/{VZL_UUID_INTERMEDIATE}"
     ParsedData = requests.get(url, timeout=10).json()
     Watts = CastToInt(ParsedData['data'][0]['tuples'][0][1])
-    logger.info("powermeter VZLogger: %s %s",Watts," Watt")
+    logger.info("intermediate meter VZLogger: %s %s",Watts," Watt")
     return CastToInt(Watts)
 
 def GetPowermeterWattsTasmota():

--- a/HoymilesZeroExport_Config.ini
+++ b/HoymilesZeroExport_Config.ini
@@ -19,7 +19,7 @@
 # ---------------------------------------------------------------------
 
 [VERSION]
-VERSION = 1.46
+VERSION = 1.47
 
 [SELECT_DTU]
 # --- define your DTU (only one) ---
@@ -36,6 +36,7 @@ USE_SHRDZM = false
 USE_EMLOG = false
 USE_IOBROKER = false
 USE_HOMEASSISTANT = false
+USE_VZLOGGER = false
 
 [AHOY_DTU]
 # --- defines for AHOY-DTU ---
@@ -110,6 +111,13 @@ HA_POWER_INPUT_ALIAS = sensor.dtz541_sml_170
 # Power-MQTT output label (negative active instantaneous power, e.g. OBIS Code 2.7.0)
 HA_POWER_OUTPUT_ALIAS = sensor.dtz541_sml_270
 
+[VZLOGGER]
+# --- defines for VZLOGGER (local http API https://wiki.volkszaehler.org/software/controller/vzlogger/vzlogger_conf_parameter#local) ---
+VZL_IP = 127.0.0.1
+VZL_PORT = 2081
+# you need to specify the uuid of the vzlogger channel for the reading OBIS(16.7.0) (aktuelle Gesamtwirkleistung)
+VZL_UUID = 30c6c501-9a3c-4b0f-bda5-1d1769904463
+
 [SELECT_INTERMEDIATE_METER]
 # if you have an intermediate meter ("Zwischenzähler") to measure the outputpower of your inverter you can set it here. It is faster than the DTU current_power value
 # --- define your intermediate meter - if you don´t have one set the following defines to false to use the value from your DTU---
@@ -123,6 +131,7 @@ USE_SHRDZM_INTERMEDIATE = false
 USE_EMLOG_INTERMEDIATE = false
 USE_IOBROKER_INTERMEDIATE = false
 USE_HOMEASSISTANT_INTERMEDIATE = false
+USE_VZLOGGER_INTERMEDIATE = false
 
 [INTERMEDIATE_TASMOTA]
 # --- defines for Tasmota Smartmeter Modul---
@@ -165,6 +174,13 @@ HA_IP_INTERMEDIATE = xxx.xxx.xxx.xxx
 HA_PORT_INTERMEDIATE = 8123
 HA_ACCESSTOKEN_INTERMEDIATE = xxx
 HA_CURRENT_POWER_ENTITY_INTERMEDIATE = sensor.dtz541_sml_curr_w
+
+[INTERMEDIATE_VZLOGGER]
+# --- defines for VZLOGGER (local http API https://wiki.volkszaehler.org/software/controller/vzlogger/vzlogger_conf_parameter#local) ---
+VZL_IP_INTERMEDIATE = 127.0.0.1
+VZL_PORT_INTERMEDIATE = 2081
+# you need to specify the uuid of the vzlogger channel for the reading OBIS(16.7.0) (aktuelle Gesamtwirkleistung)
+VZL_UUID_INTERMEDIATE = 06ec9562-a490-49fe-92ea-ffe0758d181c
 
 [COMMON]
 # Number of Inverters


### PR DESCRIPTION
Hi,
could you please merge my little extension to support vzlogger as power meter into your main branch?
More infos about vzlogger: https://wiki.volkszaehler.org/software/controller/vzlogger

I think the usage of vzlogger is still pretty common these days as it uses a wired connection to the IR-reader and is therefore very responsive.

