### PR TITLE
Add Docker support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,108 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "main"
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            base: distroless
+          - platform: linux/arm/v6
+            base: alpine
+          - platform: linux/arm/v7
+            base: alpine
+          - platform: linux/arm64
+            base: distroless
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - id: lower-repo
+        run: |
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> $GITHUB_OUTPUT
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.lower-repo.outputs.IMAGE_NAME }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          file: ./Dockerfile
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ steps.lower-repo.outputs.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          build-args: BASE=${{ matrix.base }}
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"          
+      - name: Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    needs:
+      - build
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - id: lower-repo
+        run: |
+          echo "IMAGE_NAME=${GITHUB_REPOSITORY@L}" >> $GITHUB_OUTPUT
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.lower-repo.outputs.IMAGE_NAME }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ steps.lower-repo.outputs.IMAGE_NAME }}@sha256:%s ' *)          
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ steps.lower-repo.outputs.IMAGE_NAME }}:${{ steps.meta.outputs.version }}          

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+ARG BASE=alpine
+
+FROM gcr.io/distroless/python3-debian12 AS base-distroless
+FROM python:3.11-alpine AS base-alpine
+
+FROM debian:12-slim AS build
+RUN apt-get update && \
+    apt-get install --no-install-suggests --no-install-recommends --yes python3-venv gcc libpython3-dev && \
+    python3 -m venv /venv && \
+    /venv/bin/pip install --upgrade pip setuptools wheel
+
+FROM build AS build-venv
+COPY requirements.txt /requirements.txt
+RUN /venv/bin/pip install --disable-pip-version-check -r /requirements.txt
+
+FROM base-${BASE}
+COPY --from=build-venv /venv /venv
+
+ENV PATH="/opt/venv/bin:$PATH"
+ADD HoymilesZeroExport.py /app/
+ADD HoymilesZeroExport_Config.ini /app/
+WORKDIR /app/
+ENTRYPOINT ["/venv/bin/python3", "HoymilesZeroExport.py"]

--- a/HoymilesZeroExport.py
+++ b/HoymilesZeroExport.py
@@ -30,6 +30,7 @@ from datetime import timedelta
 import datetime
 import sys
 from packaging import version
+import argparse 
 
 logging.basicConfig(
     format='%(asctime)s %(levelname)-8s %(message)s',
@@ -37,9 +38,19 @@ logging.basicConfig(
     datefmt='%Y-%m-%d %H:%M:%S')
 logger = logging.getLogger()
 
+parser = argparse.ArgumentParser()
+parser.add_argument('-c', '--config', help='Override configuration file path')
+args = parser.parse_args()
+
 try:
     config = ConfigParser()
-    config.read(str(Path.joinpath(Path(__file__).parent.resolve(), "HoymilesZeroExport_Config.ini")))
+    
+    baseconfig = str(Path.joinpath(Path(__file__).parent.resolve(), "HoymilesZeroExport_Config.ini"))
+    if args.config:
+        config.read([baseconfig, args.config])
+    else:
+        config.read(baseconfig)
+
     ENABLE_LOG_TO_FILE = config.getboolean('COMMON', 'ENABLE_LOG_TO_FILE')
     LOG_BACKUP_COUNT = config.getint('COMMON', 'LOG_BACKUP_COUNT')
 except Exception as e:
@@ -920,6 +931,9 @@ logger.info("Author: %s / Script Version: %s",__author__, __version__)
 
 # read config:
 logger.info("read config file: " + str(Path.joinpath(Path(__file__).parent.resolve(), "HoymilesZeroExport_Config.ini")))
+if args.config:
+    logger.info("read additional config file: " + args.config)
+
 VERSION = config.get('VERSION', 'VERSION')
 logger.info("Config file V %s", VERSION)
 USE_AHOY = config.getboolean('SELECT_DTU', 'USE_AHOY')

--- a/HoymilesZeroExport_Config.ini
+++ b/HoymilesZeroExport_Config.ini
@@ -23,12 +23,12 @@ VERSION = 1.60
 
 [SELECT_DTU]
 # --- define your DTU (only one) ---
-USE_AHOY = true
+USE_AHOY = false
 USE_OPENDTU = false
 
 [SELECT_POWERMETER]
 # --- define your Powermeter (only one) ---
-USE_TASMOTA = true
+USE_TASMOTA = false
 USE_SHELLY_EM = false
 USE_SHELLY_3EM = false
 USE_SHELLY_3EM_PRO = false

--- a/README.md
+++ b/README.md
@@ -79,10 +79,44 @@ sudo ./uninstall_service.sh
 ## Windows installation
 Get Python 3 (download is available at https://www.python.org/) and then install the module "requests" and "packaging":
 ```sh
-pip3 install requests
-pip3 install packaging
+pip3 install -r requirements.txt
 ```
 Now you can execute the script with python.
+
+## Docker
+
+By default the Docker image uses a base configuration in `HoymilesZeroExport_Config.ini`. You need to provide a configuration where you override individual values that. To do that, create a new `config.ini` and set the configuration values from `HoymilesZeroExport_Config.ini` you'd like to override. The minimum config file for using AhoyDTU with a Tasmota powermeter looks like this:
+```
+[SELECT_DTU]
+USE_AHOY = true
+
+[SELECT_POWERMETER]
+USE_TASMOTA = true
+
+[AHOY_DTU]
+AHOY_IP = 192.168.10.57
+
+[TASMOTA]
+TASMOTA_IP = 192.168.10.90
+```
+
+Then run the Docker image:
+```sh
+docker run -d --name hoymileszeroexport \
+    -v ${PWD}/config.ini:/app/config.ini \
+    ghcr.io/reserve85/hoymileszeroexport:main -c ./config.ini
+```
+
+Using docker-compose:
+```yaml
+version: '3.3'
+services:
+  hoymileszeroexport:
+    image: ghcr.io/reserve85/hoymileszeroexport:main
+    volumes:
+      - ./config.ini:/app/config.ini
+    command: -c ./config.ini
+```
 
 ## Special thanks to:
 - https://github.com/lumapu/ahoy

--- a/install.sh
+++ b/install.sh
@@ -12,8 +12,7 @@ if [ -z $PIP3 ]; then
   apt update
   apt -y install python3-pip
 fi
-pip3 install requests
-pip3 install packaging
+pip3 install -r requirements.txt
 echo 'Packages install completed'
 
 if systemctl --type=service --state=running | grep -Fq 'HoymilesZeroExport.service'; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+certifi==2023.11.17
+charset-normalizer==3.3.2
+idna==3.4
+packaging==23.2
+requests==2.31.0
+urllib3==2.1.0


### PR DESCRIPTION
This adds support for Docker. It builds a multi-arch Docker image and pushes it to the Github docker registry.

Other changes:
- Add requirements.txt for better dependency maintenance
- Add support for overriding config file. With this by default it takes the default config file individual configuration can set in a small override file.