### PR TITLE
Fixed path to override config within container

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ services:
     image: ghcr.io/reserve85/hoymileszeroexport:main
     volumes:
       - ./HoymilesZeroExport_Config_Override.ini:/app/config.ini
-    command: -c ./HoymilesZeroExport_Config_Override.ini
+    command: -c /app/config.ini
 ```
 
 ## Special thanks to:


### PR DESCRIPTION
The path within the container need to be the bind mound point, not the file in the host filesystem.