### PR TITLE
improve limit retry, add average panelvoltage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## V1.67
+## V1.69
+### script
+* try to fix: Only repeat limit for the specific inverter (where limit was not acknowledged)
+
+## V1.68
 ### script
 * Only repeat limit for the specific inverter (where limit was not acknowledged)
 ### Config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## V1.66
+### script
+* calculates an average of the "MinPanelVoltage", rel https://github.com/reserve85/HoymilesZeroExport/issues/120
+### Config
+* add: `INVERTER_x`: `HOY_BATTERY_AVERAGE_CNT`
+
 ## V1.65
 ### script
 * bugfix set limit retry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## V1.67
 ### script
+* Only repeat limit for the specific inverter (where limit was not acknowledged)
+### Config
+* renamed `SET_LIMIT_RETRY` to `SET_POWERSTATUS_CNT`
+
+## V1.67
+### script
 * Limit-Handling improved (if not acknowledged -> retransmit)
 
 ## V1.66

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## V1.67
+### script
+* Limit-Handling improved (if not acknowledged -> retransmit)
+
 ## V1.66
 ### script
 * calculates an average of the "MinPanelVoltage", rel https://github.com/reserve85/HoymilesZeroExport/issues/120

--- a/HoymilesZeroExport.py
+++ b/HoymilesZeroExport.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = "Tobias Kraft"
-__version__ = "1.66"
+__version__ = "1.67"
 
 import requests
 import time
@@ -115,59 +115,61 @@ def SetLimitAhoy(pInverterId, pLimit):
     CURRENT_LIMIT[pInverterId] = pLimit
 
 def WaitForAckAhoy(pInverterId, pTimeoutInS):
-    url = f'http://{AHOY_IP}/api/inverter/id/{pInverterId}'
-    timeout = pTimeoutInS
-    timeout_start = time.time()
-    while time.time() < timeout_start + timeout:
-        time.sleep(0.5)
-        ParsedData = requests.get(url, timeout=pTimeoutInS).json()
-        ack = bool(ParsedData['power_limit_ack'])
+    try:
+        url = f'http://{AHOY_IP}/api/inverter/id/{pInverterId}'
+        timeout = pTimeoutInS
+        timeout_start = time.time()
+        while time.time() < timeout_start + timeout:
+            time.sleep(0.5)
+            ParsedData = requests.get(url, timeout=pTimeoutInS).json()
+            ack = bool(ParsedData['power_limit_ack'])
+            if ack:
+                break
         if ack:
-            break
-    if ack:
-        logger.info('Ahoy: Inverter "%s": Limit acknowledged', NAME[pInverterId])
-    else:
+            logger.info('Ahoy: Inverter "%s": Limit acknowledged', NAME[pInverterId])
+        else:
+            logger.info('Ahoy: Inverter "%s": Limit timeout!', NAME[pInverterId])
+        return ack
+    except:
         logger.info('Ahoy: Inverter "%s": Limit timeout!', NAME[pInverterId])
-    return ack
+        return False
 
 def WaitForAckOpenDTU(pInverterId, pTimeoutInS):
-    url = f'http://{OPENDTU_IP}/api/limit/status'
-    timeout = pTimeoutInS
-    timeout_start = time.time()
-    while time.time() < timeout_start + timeout:
-        time.sleep(0.5)
-        ParsedData = requests.get(url, auth=HTTPBasicAuth(OPENDTU_USER, OPENDTU_PASS), timeout=10).json()
-        ack = (ParsedData[SERIAL_NUMBER[pInverterId]]['limit_set_status'] == 'Ok')
+    try:
+        url = f'http://{OPENDTU_IP}/api/limit/status'
+        timeout = pTimeoutInS
+        timeout_start = time.time()
+        while time.time() < timeout_start + timeout:
+            time.sleep(0.5)
+            ParsedData = requests.get(url, auth=HTTPBasicAuth(OPENDTU_USER, OPENDTU_PASS), timeout=10).json()
+            ack = (ParsedData[SERIAL_NUMBER[pInverterId]]['limit_set_status'] == 'Ok')
+            if ack:
+                break
         if ack:
-            break
-    if ack:
-        logger.info('OpenDTU: Inverter "%s": Limit acknowledged', NAME[pInverterId])
-    else:
+            logger.info('OpenDTU: Inverter "%s": Limit acknowledged', NAME[pInverterId])
+        else:
+            logger.info('OpenDTU: Inverter "%s": Limit timeout!', NAME[pInverterId])
+        return ack
+    except:
         logger.info('OpenDTU: Inverter "%s": Limit timeout!', NAME[pInverterId])
-    return ack
+        return False
 
 def SetLimitWithPriority(pLimit):
     try:
-        if SET_LIMIT_RETRY != -1:
-            if not hasattr(SetLimitWithPriority, "LastLimit"):
-                SetLimitWithPriority.LastLimit = CastToInt(0)
-            if not hasattr(SetLimitWithPriority, "SameLimitCnt"):
-                SetLimitWithPriority.SameLimitCnt = CastToInt(0)
-            if not hasattr(SetLimitWithPriority, "LastLimitAck"):
-                SetLimitWithPriority.LastLimitAck = bool(False)
-            if (SetLimitWithPriority.LastLimit == CastToInt(pLimit)) and SetLimitWithPriority.LastLimitAck:
-                logger.info("Inverterlimit already at %s Watt",CastToInt(pLimit))
-                return
-            if (SetLimitWithPriority.LastLimit == CastToInt(pLimit)):
-                SetLimitWithPriority.SameLimitCnt = SetLimitWithPriority.SameLimitCnt + 1
-            else:
-                SetLimitWithPriority.LastLimit = CastToInt(pLimit)
-                SetLimitWithPriority.SameLimitCnt = 0
-            if SetLimitWithPriority.SameLimitCnt >= SET_LIMIT_RETRY:
-                logger.info("Retry Counter exceeded: Inverterlimit already at %s Watt",CastToInt(pLimit))
-                time.sleep(SET_LIMIT_DELAY_IN_SECONDS)
-                return
+        if not hasattr(SetLimitWithPriority, "LastLimit"):
+            SetLimitWithPriority.LastLimit = CastToInt(0)
+        if not hasattr(SetLimitWithPriority, "LastLimitAck"):
+            SetLimitWithPriority.LastLimitAck = bool(False)
+
+        if (SetLimitWithPriority.LastLimit == CastToInt(pLimit)) and SetLimitWithPriority.LastLimitAck:
+            logger.info("Inverterlimit was already accepted at %s Watt",CastToInt(pLimit))
+            return
+        if (SetLimitWithPriority.LastLimit == CastToInt(pLimit)) and not SetLimitWithPriority.LastLimitAck:
+            logger.info("Inverterlimit %s Watt was previously not accepted by the inverter, trying again...",CastToInt(pLimit))
+            return
+
         logger.info("setting new limit to %s Watt",CastToInt(pLimit))
+        SetLimitWithPriority.LastLimit = CastToInt(pLimit)
         SetLimitWithPriority.LastLimitAck = True
         if (CastToInt(pLimit) <= GetMinWattFromAllInverters()):
             pLimit = 0 # set only minWatt for every inv.
@@ -179,7 +181,7 @@ def SetLimitWithPriority(pLimit):
                 LimitPrio = GetMaxWattFromAllInvertersSamePrio(j)
             else:
                 LimitPrio = RemainingLimit    
-            RemainingLimit = RemainingLimit - LimitPrio            
+            RemainingLimit = RemainingLimit - LimitPrio
                        
             for i in range(INVERTER_COUNT):
                 if (not AVAILABLE[i]) or (not HOY_BATTERY_GOOD_VOLTAGE[i]):
@@ -215,26 +217,19 @@ def SetLimit(pLimit):
             SetLimitWithPriority(CastToInt(pLimit))
             return
 
-        if SET_LIMIT_RETRY != -1:
-            if not hasattr(SetLimit, "LastLimit"):
-                SetLimit.LastLimit = CastToInt(0)
-            if not hasattr(SetLimit, "SameLimitCnt"):
-                SetLimit.SameLimitCnt = CastToInt(0)
-            if not hasattr(SetLimit, "LastLimitAck"):
-                SetLimit.LastLimitAck = bool(False)
-            if (SetLimit.LastLimit == CastToInt(pLimit)) and SetLimit.LastLimitAck:
-                logger.info("Inverterlimit already at %s Watt",CastToInt(pLimit))
-                return
-            if (SetLimit.LastLimit == CastToInt(pLimit)):
-                SetLimit.SameLimitCnt = SetLimit.SameLimitCnt + 1
-            else:
-                SetLimit.LastLimit = CastToInt(pLimit)
-                SetLimit.SameLimitCnt = 0
-            if SetLimit.SameLimitCnt >= SET_LIMIT_RETRY:
-                logger.info("Retry Counter exceeded: Inverterlimit already at %s Watt",CastToInt(pLimit))
-                time.sleep(SET_LIMIT_DELAY_IN_SECONDS)
-                return
+        if not hasattr(SetLimit, "LastLimit"):
+            SetLimit.LastLimit = CastToInt(0)
+        if not hasattr(SetLimit, "LastLimitAck"):
+            SetLimit.LastLimitAck = bool(False)
+
+        if (SetLimit.LastLimit == CastToInt(pLimit)) and SetLimit.LastLimitAck:
+            logger.info("Inverterlimit was already accepted at %s Watt",CastToInt(pLimit))
+            return
+        if (SetLimit.LastLimit == CastToInt(pLimit)) and not SetLimit.LastLimitAck:
+            logger.info("Inverterlimit %s Watt was previously not accepted by the inverter, trying again...",CastToInt(pLimit))
+
         logger.info("setting new limit to %s Watt",CastToInt(pLimit))
+        SetLimit.LastLimit = CastToInt(pLimit)
         SetLimit.LastLimitAck = True
         if (CastToInt(pLimit) <= GetMinWattFromAllInverters()):
             pLimit = 0 # set only minWatt for every inv.
@@ -292,6 +287,14 @@ def GetHoymilesAvailable():
                 if AVAILABLE[i]:
                     GetHoymilesAvailable = True
                     if not WasAvail:
+                        if hasattr(SetLimit, "LastLimit"):
+                            SetLimit.LastLimit = CastToInt(0)
+                        if hasattr(SetLimit, "LastLimitAck"):
+                            SetLimit.LastLimitAck = bool(False)
+                        if hasattr(SetLimitWithPriority, "LastLimit"):
+                            SetLimitWithPriority.LastLimit = CastToInt(0)
+                        if hasattr(SetLimitWithPriority, "LastLimitAck"):
+                            SetLimitWithPriority.LastLimitAck = bool(False)
                         GetHoymilesInfo()
             except Exception as e:
                 AVAILABLE[i] = False
@@ -304,7 +307,7 @@ def GetHoymilesAvailable():
     except:
         logger.error('Exception at GetHoymilesAvailable')
         raise
-    
+
 def CheckAhoyVersion():
     MinVersion = '0.7.29'
     url = f'http://{AHOY_IP}/api/system'
@@ -1104,10 +1107,6 @@ SLOW_APPROX_LIMIT = CastToInt(GetMaxWattFromAllInverters() * config.getint('COMM
 try:
     logger.info("---Init---")
     newLimitSetpoint = 0
-    
-    GetHoymilesPanelMinVoltage(0)
-    
-    
     if USE_AHOY:
         CheckAhoyVersion()
         AHOY_FACTOR = GetAhoyLimitFactor()

--- a/HoymilesZeroExport.py
+++ b/HoymilesZeroExport.py
@@ -421,7 +421,6 @@ def GetHoymilesPanelMinVoltageOpenDTU(pInverterId):
         if (max_value is None or num > max_value):
             max_value = num
 
-    logger.info('Lowest panel voltage inverter "%s": %s Volt',NAME[pInverterId],max_value)
     return max_value
 
 def GetHoymilesPanelMinVoltage(pInverterId):
@@ -441,6 +440,8 @@ def GetHoymilesPanelMinVoltage(pInverterId):
         if len(HOY_PANEL_MIN_VOLTAGE_HISTORY_LIST[pInverterId]) > 5:
             HOY_PANEL_MIN_VOLTAGE_HISTORY_LIST[pInverterId].pop(0)
         from statistics import mean
+        
+        logger.info('Average min-panel voltage, inverter "%s": %s Volt',NAME[pInverterId], mean(HOY_PANEL_MIN_VOLTAGE_HISTORY_LIST[pInverterId]))
         return mean(HOY_PANEL_MIN_VOLTAGE_HISTORY_LIST[pInverterId])
     except:
         logger.error("Exception at GetHoymilesPanelMinVoltage, Inverter %s not reachable", pInverterId)

--- a/HoymilesZeroExport_Config.ini
+++ b/HoymilesZeroExport_Config.ini
@@ -19,7 +19,7 @@
 # ---------------------------------------------------------------------
 
 [VERSION]
-VERSION = 1.64
+VERSION = 1.66
 
 [SELECT_DTU]
 # --- define your DTU (only one) ---
@@ -261,6 +261,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_2]
 # power rating of your inverter
@@ -296,6 +298,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_3]
 # power rating of your inverter
@@ -331,6 +335,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_4]
 # power rating of your inverter
@@ -366,6 +372,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_5]
 # power rating of your inverter
@@ -401,6 +409,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_6]
 # power rating of your inverter
@@ -436,6 +446,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_7]
 # power rating of your inverter
@@ -471,6 +483,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_8]
 # power rating of your inverter
@@ -506,6 +520,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_9]
 # power rating of your inverter
@@ -541,6 +557,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_10]
 # power rating of your inverter
@@ -576,6 +594,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_11]
 # power rating of your inverter
@@ -611,6 +631,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_12]
 # power rating of your inverter
@@ -646,6 +668,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_13]
 # power rating of your inverter
@@ -681,6 +705,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_14]
 # power rating of your inverter
@@ -716,6 +742,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_15]
 # power rating of your inverter
@@ -751,6 +779,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_16]
 # power rating of your inverter
@@ -786,6 +816,8 @@ HOY_BATTERY_IGNORE_PANELS =
 # set limit of 1100W -> inverter 1 is set to 1000W and inverter 2 is set to 100W
 # set limit of 300W -> inverter 1 is set to 300W and inverter 2 is powered off
 HOY_BATTERY_PRIORITY = 1
+# Number of measured values for the moving average of the min panel voltage
+HOY_BATTERY_AVERAGE_CNT = 1
 
 # grid power
 #    ...

--- a/HoymilesZeroExport_Config.ini
+++ b/HoymilesZeroExport_Config.ini
@@ -19,7 +19,7 @@
 # ---------------------------------------------------------------------
 
 [VERSION]
-VERSION = 1.66
+VERSION = 1.68
 
 [SELECT_DTU]
 # --- define your DTU (only one) ---
@@ -208,8 +208,8 @@ MAX_DIFFERENCE_BETWEEN_LIMIT_AND_OUTPUTPOWER = 100
 ENABLE_LOG_TO_FILE = false
 # how many logfiles you wish to keep
 LOG_BACKUP_COUNT = 30
-# defines how often a identical limit will be set, set it to "-1" for disabled (infinite repeat)
-SET_LIMIT_RETRY = 10
+# defines how often the Inverter Power Status will be set, set it to "-1" for disabled (infinite repeat)
+SET_POWERSTATUS_CNT = 10
 # log the inverter temperature
 LOG_TEMPERATURE = false
 # delay time after turning the inverter off or on


### PR DESCRIPTION
## V1.69
### script
* try to fix: Only repeat limit for the specific inverter (where limit was not acknowledged)

## V1.68
### script
* Only repeat limit for the specific inverter (where limit was not acknowledged)
### Config
* renamed `SET_LIMIT_RETRY` to `SET_POWERSTATUS_CNT`

## V1.67
### script
* Limit-Handling improved (if not acknowledged -> retransmit)

## V1.66
### script
* calculates an average of the "MinPanelVoltage", rel https://github.com/reserve85/HoymilesZeroExport/issues/120
### Config
* add: `INVERTER_x`: `HOY_BATTERY_AVERAGE_CNT`