### PR TITLE
openDTU: prevent inverter mix-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## V1.78
+### script
+* openDTU: don´t override serialnumber every time a inverter gets available
+### config
+* optional field in : `INVERTER_x`: `SERIAL_NUMBER`: If you use more than one inverter you should define the serialnumber(s) in the config. Else a mix-up of the inverters possible (only openDTU)
+
 ## V1.77
 ### script
 * fixed wrong calculation "RemainingDelay"

--- a/HoymilesZeroExport.py
+++ b/HoymilesZeroExport.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = "Tobias Kraft"
-__version__ = "1.77"
+__version__ = "1.78"
 
 import requests
 import time
@@ -854,8 +854,9 @@ class OpenDTU(DTU):
         return Reachable
     
     def GetInfo(self, pInverterId: int):
-        ParsedData = self.GetJson('/api/livedata/status')
-        SERIAL_NUMBER[pInverterId] = str(ParsedData['inverters'][pInverterId]['serial'])
+        if SERIAL_NUMBER[pInverterId] == '':
+            ParsedData = self.GetJson('/api/livedata/status')
+            SERIAL_NUMBER[pInverterId] = str(ParsedData['inverters'][pInverterId]['serial'])
 
         ParsedData = self.GetJson(f'/api/livedata/status?inv={SERIAL_NUMBER[pInverterId]}')
         TEMPERATURE[pInverterId] = str(round(float((ParsedData['inverters'][0]['INV']['0']['Temperature']['v'])),1)) + ' degC'
@@ -1133,7 +1134,7 @@ HOY_PANEL_VOLTAGE_LIST = []
 HOY_PANEL_MIN_VOLTAGE_HISTORY_LIST = []
 HOY_BATTERY_AVERAGE_CNT = []
 for i in range(INVERTER_COUNT):
-    SERIAL_NUMBER.append(str('yet unknown'))
+    SERIAL_NUMBER.append(config.get('INVERTER_' + str(i + 1), 'SERIAL_NUMBER', fallback=''))
     NAME.append(str('yet unknown'))
     TEMPERATURE.append(str('--- degC'))
     HOY_MAX_WATT.append(config.getint('INVERTER_' + str(i + 1), 'HOY_MAX_WATT'))

--- a/HoymilesZeroExport_Config.ini
+++ b/HoymilesZeroExport_Config.ini
@@ -19,7 +19,7 @@
 # ---------------------------------------------------------------------
 
 [VERSION]
-VERSION = 1.76
+VERSION = 1.78
 
 [SELECT_DTU]
 # --- define your DTU (only one) ---
@@ -227,6 +227,8 @@ POWERMETER_MAX_POINT = 0
 
 # List of INVERTERS, based on COMMON/COUNT
 [INVERTER_1]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
@@ -264,6 +266,8 @@ HOY_BATTERY_PRIORITY = 1
 HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_2]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
@@ -301,6 +305,8 @@ HOY_BATTERY_PRIORITY = 1
 HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_3]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
@@ -338,6 +344,8 @@ HOY_BATTERY_PRIORITY = 1
 HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_4]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
@@ -375,6 +383,8 @@ HOY_BATTERY_PRIORITY = 1
 HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_5]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
@@ -412,6 +422,8 @@ HOY_BATTERY_PRIORITY = 1
 HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_6]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
@@ -449,6 +461,8 @@ HOY_BATTERY_PRIORITY = 1
 HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_7]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
@@ -486,6 +500,8 @@ HOY_BATTERY_PRIORITY = 1
 HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_8]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
@@ -523,6 +539,8 @@ HOY_BATTERY_PRIORITY = 1
 HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_9]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
@@ -560,6 +578,8 @@ HOY_BATTERY_PRIORITY = 1
 HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_10]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
@@ -597,6 +617,8 @@ HOY_BATTERY_PRIORITY = 1
 HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_11]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
@@ -634,6 +656,8 @@ HOY_BATTERY_PRIORITY = 1
 HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_12]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
@@ -671,6 +695,8 @@ HOY_BATTERY_PRIORITY = 1
 HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_13]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
@@ -708,6 +734,8 @@ HOY_BATTERY_PRIORITY = 1
 HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_14]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
@@ -745,6 +773,8 @@ HOY_BATTERY_PRIORITY = 1
 HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_15]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%
@@ -782,6 +812,8 @@ HOY_BATTERY_PRIORITY = 1
 HOY_BATTERY_AVERAGE_CNT = 1
 
 [INVERTER_16]
+# serial number of your inverter, if empty it is automatically read out of the API. If you have more than one inverter you should define the serial number here (prevents mix-up).
+SERIAL_NUMBER = 
 # power rating of your inverter
 HOY_MAX_WATT = 1500
 # minimum limit in percent, e.g. 5%


### PR DESCRIPTION
## V1.78
### script
* openDTU: don´t override serialnumber every time a inverter gets available 
### config
* optional field in : `INVERTER_x`: `SERIAL_NUMBER`: If you use more than one inverter you should define the serialnumber(s) in the config. Else a mix-up of the inverters possible (only openDTU)

https://github.com/reserve85/HoymilesZeroExport/issues/142