### PR TITLE
Use absolute intermediate power watts

### DIFF
--- a/HoymilesZeroExport.py
+++ b/HoymilesZeroExport.py
@@ -365,7 +365,7 @@ def GetHoymilesTemperature():
 def GetHoymilesActualPower():
     try:
         try:
-            Watts = INTERMEDIATE_POWERMETER.GetPowermeterWatts()
+            Watts = abs(INTERMEDIATE_POWERMETER.GetPowermeterWatts())
             logger.info(f"intermediate meter {INTERMEDIATE_POWERMETER.__class__.__name__}: {Watts} Watt")
             return Watts
         except Exception as e:


### PR DESCRIPTION
Intermediate meters measure consumption, so those are often negative. This uses the absolute value, assuming that an intermediate meter would never measure a consumer and a producer simultaneously.