### PR TITLE
Update workflow to run on tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - "main"
+  create:
+    tags:
+      - "*"
+
 env:
   REGISTRY: ghcr.io
 


### PR DESCRIPTION
With this, docker images get built and tagged whenever a git tag is pushed.

Fixes #153