### PR TITLE
Add AMIS reader support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## V1.92
+### script
+* support "Mitterbaur AMIS Lesekopf" (https://github.com/reserve85/HoymilesZeroExport/issues/184)
+### config
+* add `[SELECT_POWERMETER]`: `USE_AMIS_READER` 
+* add `[AMIS_READER]`: `AMIS_READER_IP`
+* add `[SELECT_INTERMEDIATE_METER]`: `USE_AMIS_READER_INTERMEDIATE` 
+* add `[INTERMEDIATE_AMIS_READER]`: `AMIS_READER_IP_INTERMEDIATE`
+
 ## V1.91
 ### script
 * support Home Assistant over HTTPS (https://github.com/reserve85/HoymilesZeroExport/issues/178)

--- a/HoymilesZeroExport.py
+++ b/HoymilesZeroExport.py
@@ -1200,7 +1200,7 @@ def CreatePowermeter() -> Powermeter:
             config.get('SCRIPT', 'SCRIPT_PASS')
         )
     elif config.getboolean('SELECT_POWERMETER', 'USE_AMIS_READER'):
-        return VZLogger(
+        return AmisReader(
             config.get('AMIS_READER', 'AMIS_READER_IP')
         )
     else:
@@ -1279,7 +1279,7 @@ def CreateIntermediatePowermeter(dtu: DTU) -> Powermeter:
             config.get('INTERMEDIATE_VZLOGGER', 'VZL_UUID_INTERMEDIATE')
         )
     elif config.getboolean('SELECT_POWERMETER', 'USE_AMIS_READER_INTERMEDIATE'):
-        return VZLogger(
+        return AmisReader(
             config.get('INTERMEDIATE_AMIS_READER', 'AMIS_READER_IP_INTERMEDIATE')
         )        
     else:

--- a/HoymilesZeroExport.py
+++ b/HoymilesZeroExport.py
@@ -1278,7 +1278,7 @@ def CreateIntermediatePowermeter(dtu: DTU) -> Powermeter:
             config.get('INTERMEDIATE_VZLOGGER', 'VZL_PORT_INTERMEDIATE'),
             config.get('INTERMEDIATE_VZLOGGER', 'VZL_UUID_INTERMEDIATE')
         )
-    elif config.getboolean('SELECT_POWERMETER', 'USE_AMIS_READER_INTERMEDIATE'):
+    elif config.getboolean('SELECT_INTERMEDIATE_METER', 'USE_AMIS_READER_INTERMEDIATE'):
         return AmisReader(
             config.get('INTERMEDIATE_AMIS_READER', 'AMIS_READER_IP_INTERMEDIATE')
         )        

--- a/HoymilesZeroExport.py
+++ b/HoymilesZeroExport.py
@@ -15,7 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 __author__ = "Tobias Kraft"
-__version__ = "1.91"
+__version__ = "1.92"
 
 import requests
 import time
@@ -817,6 +817,18 @@ class VZLogger(Powermeter):
     def GetPowermeterWatts(self):
         return CastToInt(self.GetJson()['data'][0]['tuples'][0][1])
 
+class AmisReader(Powermeter):
+    def __init__(self, ip: str):
+        self.ip = ip
+
+    def GetJson(self, path):
+        url = f'http://{self.ip}{path}'
+        return session.get(url, timeout=10).json()
+
+    def GetPowermeterWatts(self):
+        ParsedData = self.GetJson(f'/rest')
+        return CastToInt(ParsedData['saldo'])
+
 class DTU(Powermeter):
     def __init__(self, inverter_count: int):
         self.inverter_count = inverter_count
@@ -1187,6 +1199,10 @@ def CreatePowermeter() -> Powermeter:
             config.get('SCRIPT', 'SCRIPT_USER'),
             config.get('SCRIPT', 'SCRIPT_PASS')
         )
+    elif config.getboolean('SELECT_POWERMETER', 'USE_AMIS_READER'):
+        return VZLogger(
+            config.get('AMIS_READER', 'AMIS_READER_IP')
+        )
     else:
         raise Exception("Error: no powermeter defined!")
 
@@ -1262,6 +1278,10 @@ def CreateIntermediatePowermeter(dtu: DTU) -> Powermeter:
             config.get('INTERMEDIATE_VZLOGGER', 'VZL_PORT_INTERMEDIATE'),
             config.get('INTERMEDIATE_VZLOGGER', 'VZL_UUID_INTERMEDIATE')
         )
+    elif config.getboolean('SELECT_POWERMETER', 'USE_AMIS_READER_INTERMEDIATE'):
+        return VZLogger(
+            config.get('INTERMEDIATE_AMIS_READER', 'AMIS_READER_IP_INTERMEDIATE')
+        )        
     else:
         return dtu
 

--- a/HoymilesZeroExport_Config.ini
+++ b/HoymilesZeroExport_Config.ini
@@ -19,7 +19,7 @@
 # ---------------------------------------------------------------------
 
 [VERSION]
-VERSION = 1.91
+VERSION = 1.92
 
 [SELECT_DTU]
 # --- define your DTU (only one) ---
@@ -38,6 +38,7 @@ USE_IOBROKER = false
 USE_HOMEASSISTANT = false
 USE_VZLOGGER = false
 USE_SCRIPT = false
+USE_AMIS_READER = false
 
 [AHOY_DTU]
 # --- defines for AHOY-DTU ---
@@ -136,6 +137,10 @@ SCRIPT_FILE = GetPowerFromVictronMultiplus.sh
 SCRIPT_USER =
 SCRIPT_PASS =
 
+# --- defines for Mitterbaur AMIS Reader ---
+[AMIS_READER]
+AMIS_READER_IP = xxx.xxx.xxx.xxx
+
 [SELECT_INTERMEDIATE_METER]
 # if you have an intermediate meter ("Zwischenzähler") to measure the outputpower of your inverter you can set it here. It is faster than the DTU current_power value
 # --- define your intermediate meter - if you don´t have one set the following defines to false to use the value from your DTU---
@@ -151,6 +156,7 @@ USE_EMLOG_INTERMEDIATE = false
 USE_IOBROKER_INTERMEDIATE = false
 USE_HOMEASSISTANT_INTERMEDIATE = false
 USE_VZLOGGER_INTERMEDIATE = false
+USE_AMIS_READER_INTERMEDIATE = false
 
 [INTERMEDIATE_TASMOTA]
 # --- defines for Tasmota Smartmeter Modul---
@@ -213,6 +219,10 @@ VZL_IP_INTERMEDIATE = 127.0.0.1
 VZL_PORT_INTERMEDIATE = 2081
 # you need to specify the uuid of the vzlogger channel for the reading OBIS(16.7.0) (aktuelle Gesamtwirkleistung)
 VZL_UUID_INTERMEDIATE = 06ec9562-a490-49fe-92ea-ffe0758d181c
+
+# --- defines for Mitterbaur AMIS Reader ---
+[INTERMEDIATE_AMIS_READER]
+AMIS_READER_IP_INTERMEDIATE = xxx.xxx.xxx.xxx
 
 # Uncomment the following section if you want to use MQTT to dynamically reconfigure some settings while the script is running
 # [MQTT_CONFIG]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This script does not use MQTT, it's based on webapi communication.
 - [HomeAssistant](https://www.home-assistant.io/)
 - [Volkszaehler (VZLogger)](https://volkszaehler.org/)
 - [ESPHome](https://esphome.io/)
+- [Mitterbaur Amis Reader](https://www.mitterbaur.at/amis-leser.html)
 - shell script based interface
 - easy to implement new smart meter modules supporting WebAPI / JSON
 


### PR DESCRIPTION
## V1.92
### script
* support "Mitterbaur AMIS Lesekopf" (https://github.com/reserve85/HoymilesZeroExport/issues/184)
### config
* add `[SELECT_POWERMETER]`: `USE_AMIS_READER` 
* add `[AMIS_READER]`: `AMIS_READER_IP`
* add `[SELECT_INTERMEDIATE_METER]`: `USE_AMIS_READER_INTERMEDIATE` 
* add `[INTERMEDIATE_AMIS_READER]`: `AMIS_READER_IP_INTERMEDIATE`