### PR TITLE
add POWERMETER_MIN_POINT functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## V1.94
+### script
+* add script functionality for a super high priority limit change if your powermeter falls below POWERMETER_MIN_POINT (https://github.com/reserve85/HoymilesZeroExport/issues/197)
+### config
+* add `[CONTROL]`: `POWERMETER_MIN_POINT`
+* add `[COMMON]`: `ON_GRID_FEED_JUMP_TO_LIMIT_PERCENT`
+
 ## V1.93
 ### script
 * support script for intermediate meter (https://github.com/reserve85/HoymilesZeroExport/issues/197)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## V1.94
 ### script
-* add script functionality for a super high priority limit change if your powermeter falls below POWERMETER_MIN_POINT (https://github.com/reserve85/HoymilesZeroExport/issues/197)
+* add script functionality for a super high priority limit change if your powermeter falls below POWERMETER_MIN_POINT (https://github.com/reserve85/HoymilesZeroExport/issues/200)
 ### config
 * add `[CONTROL]`: `POWERMETER_MIN_POINT`
-* add `[COMMON]`: `ON_GRID_FEED_JUMP_TO_LIMIT_PERCENT`
+* add `[COMMON]`: `ON_GRID_FEED_FAST_LIMIT_DECREASE`
 
 ## V1.93
 ### script

--- a/HoymilesZeroExport.py
+++ b/HoymilesZeroExport.py
@@ -1435,7 +1435,7 @@ logger.info("---Start Zero Export---")
 while True:
     CONFIG_PROVIDER.update()
     on_grid_usage_jump_to_limit_percent = CONFIG_PROVIDER.on_grid_usage_jump_to_limit_percent()
-    on_grid_feed_jump_to_limit_percent = CONFIG_PROVIDER.on_grid_feed_jump_to_limit_percent()    
+    on_grid_feed_fast_limit_decrease = CONFIG_PROVIDER.on_grid_feed_fast_limit_decrease()    
     powermeter_target_point = CONFIG_PROVIDER.get_powermeter_target_point()
     powermeter_max_point = CONFIG_PROVIDER.get_powermeter_max_point()
     powermeter_min_point = CONFIG_PROVIDER.get_powermeter_min_point()
@@ -1466,13 +1466,8 @@ while True:
                     if RemainingDelay > 0:
                         time.sleep(RemainingDelay)
                         break
-                elif powermeterWatts < powermeter_min_point:
-                    if on_grid_feed_jump_to_limit_percent > 0:
-                        newLimitSetpoint = CastToInt(GetMaxInverterWattFromAllInverters() * on_grid_feed_jump_to_limit_percent / 100)
-                        if (newLimitSetpoint >= PreviousLimitSetpoint) and (on_grid_feed_jump_to_limit_percent != 100):
-                            newLimitSetpoint = PreviousLimitSetpoint + powermeterWatts - powermeter_target_point
-                    else:
-                        newLimitSetpoint = PreviousLimitSetpoint + powermeterWatts - powermeter_target_point
+                elif (powermeterWatts < powermeter_min_point) and on_grid_feed_fast_limit_decrease:
+                    newLimitSetpoint = PreviousLimitSetpoint + powermeterWatts - powermeter_target_point
                     newLimitSetpoint = ApplyLimitsToSetpoint(newLimitSetpoint)
                     SetLimit(newLimitSetpoint)
                     RemainingDelay = CastToInt((LOOP_INTERVAL_IN_SECONDS / POLL_INTERVAL_IN_SECONDS - x) * POLL_INTERVAL_IN_SECONDS)

--- a/HoymilesZeroExport_Config.ini
+++ b/HoymilesZeroExport_Config.ini
@@ -19,8 +19,7 @@
 # ---------------------------------------------------------------------
 
 [VERSION]
-VERSION = 1.93
-
+VERSION = 1.94
 [SELECT_DTU]
 # --- define your DTU (only one) ---
 USE_AHOY = false
@@ -268,6 +267,9 @@ POLL_INTERVAL_IN_SECONDS = 1
 # if your powermeter exceeds POWERMETER_MAX_POINT: immediatelly set the limit to predefined percent of HOY_MAX_WATT (if you have more than one inverter it´s the sum of all HOY_MAX_WATT)
 # value = 0 disables the feature. Values are possible from [0 to 100]
 ON_GRID_USAGE_JUMP_TO_LIMIT_PERCENT = 100
+# if your powermeter falls below POWERMETER_MIN_POINT: immediatelly set the limit to predefined percent of HOY_MAX_WATT (if you have more than one inverter it´s the sum of all HOY_MAX_WATT)
+# value = 0 disables the feature. Values are possible from [0 to 100]
+ON_GRID_FEED_JUMP_TO_LIMIT_PERCENT = 0
 # max difference between Limit and real output power in % of HOY_MAX_WATT (100 = disabled)
 MAX_DIFFERENCE_BETWEEN_LIMIT_AND_OUTPUTPOWER = 100
 # enable logging to file
@@ -299,6 +301,10 @@ POWERMETER_TOLERANCE = 25
 # if your powermeter jumps over this point, the limit will be increased instantly. it is like a "super high priority limit change".
 # if you defined ON_GRID_USAGE_JUMP_TO_LIMIT_PERCENT > 0, then the limit will jump to the defined percent when reaching this point.
 POWERMETER_MAX_POINT = 0
+# POWERMETER_MIN_POINT is the minimum power of your powermeter for the normal "regulation loop".
+# if your powermeter jumps under this point, the limit will be reduced instantly. it is like a "super high priority limit change".
+# if you defined ON_GRID_FEED_JUMP_TO_LIMIT_PERCENT > 0, then the limit will jump to the defined percent when it is lower than this point.
+POWERMETER_MIN_POINT = -600
 
 # List of INVERTERS, based on COMMON/COUNT
 [INVERTER_1]

--- a/HoymilesZeroExport_Config.ini
+++ b/HoymilesZeroExport_Config.ini
@@ -267,9 +267,8 @@ POLL_INTERVAL_IN_SECONDS = 1
 # if your powermeter exceeds POWERMETER_MAX_POINT: immediatelly set the limit to predefined percent of HOY_MAX_WATT (if you have more than one inverter it´s the sum of all HOY_MAX_WATT)
 # value = 0 disables the feature. Values are possible from [0 to 100]
 ON_GRID_USAGE_JUMP_TO_LIMIT_PERCENT = 100
-# if your powermeter falls below POWERMETER_MIN_POINT: immediatelly set the limit to predefined percent of HOY_MAX_WATT (if you have more than one inverter it´s the sum of all HOY_MAX_WATT)
-# value = 0 disables the feature. Values are possible from [0 to 100]
-ON_GRID_FEED_JUMP_TO_LIMIT_PERCENT = 0
+# if your powermeter falls below POWERMETER_MIN_POINT: immediatelly decrease the limit
+ON_GRID_FEED_FAST_LIMIT_DECREASE = false
 # max difference between Limit and real output power in % of HOY_MAX_WATT (100 = disabled)
 MAX_DIFFERENCE_BETWEEN_LIMIT_AND_OUTPUTPOWER = 100
 # enable logging to file
@@ -303,7 +302,6 @@ POWERMETER_TOLERANCE = 25
 POWERMETER_MAX_POINT = 0
 # POWERMETER_MIN_POINT is the minimum power of your powermeter for the normal "regulation loop".
 # if your powermeter jumps under this point, the limit will be reduced instantly. it is like a "super high priority limit change".
-# if you defined ON_GRID_FEED_JUMP_TO_LIMIT_PERCENT > 0, then the limit will jump to the defined percent when it is lower than this point.
 POWERMETER_MIN_POINT = -600
 
 # List of INVERTERS, based on COMMON/COUNT

--- a/config_provider.py
+++ b/config_provider.py
@@ -25,12 +25,26 @@ class ConfigProvider:
         If you defined ON_GRID_USAGE_JUMP_TO_LIMIT_PERCENT > 0, then the limit will jump to the defined percent when reaching this point.
         """
         pass
+    
+    def get_powermeter_min_point(self):
+        """
+        The minimum power of your powermeter for the normal "regulation loop".
+        if your powermeter jumps under this point, the limit will be reduced instantly. it is like a "super high priority limit change".
+        if you defined ON_GRID_FEED_JUMP_TO_LIMIT_PERCENT > 0, then the limit will jump to the defined percent when it is lower than this point.
+        """
+        pass
 
     def on_grid_usage_jump_to_limit_percent(self):
         """
         If the powermeter jumps over the max point, the limit will be increased to this percent of the powermeter value.
         """
         pass
+    
+    def on_grid_feed_jump_to_limit_percent(self):
+        """
+        If the powermeter falls below the min point, the limit will be increased to this percent of the powermeter value.
+        """
+        pass    
 
     def get_powermeter_tolerance(self):
         """
@@ -85,12 +99,18 @@ class ConfigFileConfigProvider(ConfigProvider):
 
     def get_powermeter_max_point(self):
         return self.config.getint('CONTROL', 'POWERMETER_MAX_POINT')
+    
+    def get_powermeter_min_point(self):
+        return self.config.getint('CONTROL', 'POWERMETER_MIN_POINT')
 
     def get_powermeter_tolerance(self):
         return self.config.getint('CONTROL', 'POWERMETER_TOLERANCE')
 
     def on_grid_usage_jump_to_limit_percent(self):
         return self.config.getint('COMMON', 'ON_GRID_USAGE_JUMP_TO_LIMIT_PERCENT')
+    
+    def on_grid_feed_jump_to_limit_percent(self):
+        return self.config.getint('COMMON', 'ON_GRID_FEED_JUMP_TO_LIMIT_PERCENT')    
 
     def get_min_wattage_in_percent(self, inverter_idx):
         return self.config.getint('INVERTER_' + str(inverter_idx + 1), 'HOY_MIN_WATT_IN_PERCENT')
@@ -152,7 +172,7 @@ class OverridingConfigProvider(ConfigProvider):
             else:
                 logger.error(f"Unknown inverter key {key}")
         else:
-            if key in ['powermeter_target_point', 'powermeter_max_point', 'powermeter_tolerance', 'on_grid_usage_jump_to_limit_percent']:
+            if key in ['powermeter_target_point', 'powermeter_max_point', 'powermeter_min_point', 'powermeter_tolerance', 'on_grid_usage_jump_to_limit_percent', 'on_grid_feed_jump_to_limit_percent']:
                 return int(value)
             else:
                 logger.error(f"Unknown common key {key}")
@@ -185,11 +205,17 @@ class OverridingConfigProvider(ConfigProvider):
     def get_powermeter_max_point(self):
         return self.common_config.get('powermeter_max_point')
 
+    def get_powermeter_min_point(self):
+        return self.common_config.get('powermeter_min_point')    
+
     def get_powermeter_tolerance(self):
         return self.common_config.get('powermeter_tolerance')
 
     def on_grid_usage_jump_to_limit_percent(self):
         return self.common_config.get('on_grid_usage_jump_to_limit_percent')
+    
+    def on_grid_feed_jump_to_limit_percent(self):
+        return self.common_config.get('on_grid_feed_jump_to_limit_percent')    
 
     def get_min_wattage_in_percent(self, inverter_idx):
         if inverter_idx >= len(self.inverter_config):
@@ -226,8 +252,10 @@ class MqttConfigProvider(OverridingConfigProvider):
         self.reset_topic = reset_topic
         self.target_point = None
         self.max_point = None
+        self.min_point = None
         self.tolerance = None
         self.on_grid_usage_jump_to_limit_percent = None
+        self.on_grid_feed_jump_to_limit_percent = None
         self.min_wattage_in_percent = []
         self.normal_wattage = []
         self.reduce_wattage = []


### PR DESCRIPTION
## V1.94
### script
* add script functionality for a super high priority limit change if your powermeter falls below POWERMETER_MIN_POINT (https://github.com/reserve85/HoymilesZeroExport/issues/200)
### config
* add `[CONTROL]`: `POWERMETER_MIN_POINT`
* add `[COMMON]`: `ON_GRID_FEED_FAST_LIMIT_DECREASE`