### PR TITLE
Publish state to MQTT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## V1.95
+### script
+* publish an online/offline status message to MQTT
+* publish config state to MQTT
+* publish the current (inverter) limit to MQTT
+* publish logs to MQTT
+### config
+* replace `MQTT_CONFIG`:`MQTT_SET_TOPIC` and `MQTT_CONFIG`:`MQTT_RESET_TOPIC` with `MQTT_CONFIG`:`MQTT_TOPIC_PREFIX`
+* add `MQTT_CONFIG`:`MQTT_LOG_LEVEL` - if set, log messages will be published to MQTT
+
 ## V1.94
 ### script
 * add script functionality for a super high priority limit change if your powermeter falls below POWERMETER_MIN_POINT (https://github.com/reserve85/HoymilesZeroExport/issues/200)

--- a/HoymilesZeroExport.py
+++ b/HoymilesZeroExport.py
@@ -33,7 +33,7 @@ import sys
 from packaging import version
 import argparse 
 import subprocess
-from config_provider import ConfigFileConfigProvider, MqttConfigProvider, ConfigProviderChain
+from config_provider import ConfigFileConfigProvider, MqttHandler, ConfigProviderChain
 
 session = Session()
 logging.basicConfig(
@@ -117,8 +117,12 @@ def SetLimitWithPriority(pLimit):
         logger.info("setting new limit to %s Watt",CastToInt(pLimit))
         SetLimitWithPriority.LastLimit = CastToInt(pLimit)
         SetLimitWithPriority.LastLimitAck = True
-        if (CastToInt(pLimit) <= GetMinWattFromAllInverters()):
+        min_watt_all_inverters = GetMinWattFromAllInverters()
+        if (CastToInt(pLimit) <= min_watt_all_inverters):
             pLimit = 0 # set only minWatt for every inv.
+            PublishGlobalState("limit", min_watt_all_inverters)
+        else:
+            PublishGlobalState("limit", CastToInt(pLimit))
         RemainingLimit = CastToInt(pLimit)
         for j in range (1,6):
             if GetMaxWattFromAllInvertersSamePrio(j) <= 0:
@@ -147,6 +151,7 @@ def SetLimitWithPriority(pLimit):
 
                 LASTLIMITACKNOWLEDGED[i] = True
 
+                PublishInverterState(i, "limit", NewLimit)
                 DTU.SetLimit(i, NewLimit)
                 if not DTU.WaitForAck(i, SET_LIMIT_TIMEOUT_SECONDS):
                     SetLimitWithPriority.LastLimitAck = False
@@ -172,8 +177,12 @@ def SetLimitMixedModeWithPriority(pLimit):
         logger.info("setting new limit to %s Watt",CastToInt(pLimit))
         SetLimitMixedModeWithPriority.LastLimit = CastToInt(pLimit)
         SetLimitMixedModeWithPriority.LastLimitAck = True
-        if (CastToInt(pLimit) <= GetMinWattFromAllInverters()):
+        min_watt_all_inverters = GetMinWattFromAllInverters()
+        if (CastToInt(pLimit) <= min_watt_all_inverters):
             pLimit = 0 # set only minWatt for every inv.
+            PublishGlobalState("limit", min_watt_all_inverters)
+        else:
+            PublishGlobalState("limit", CastToInt(pLimit))
         RemainingLimit = CastToInt(pLimit)
 
         # Handle non-battery inverters first
@@ -203,6 +212,7 @@ def SetLimitMixedModeWithPriority(pLimit):
 
             LASTLIMITACKNOWLEDGED[i] = True
 
+            PublishInverterState(i, "limit", NewLimit)
             DTU.SetLimit(i, NewLimit)
             if not DTU.WaitForAck(i, SET_LIMIT_TIMEOUT_SECONDS):
                 SetLimitMixedModeWithPriority.LastLimitAck = False
@@ -243,6 +253,7 @@ def SetLimitMixedModeWithPriority(pLimit):
 
                 LASTLIMITACKNOWLEDGED[i] = True
 
+                PublishInverterState(i, "limit", NewLimit)
                 DTU.SetLimit(i, NewLimit)
                 if not DTU.WaitForAck(i, SET_LIMIT_TIMEOUT_SECONDS):
                     SetLimitMixedModeWithPriority.LastLimitAck = False
@@ -305,8 +316,12 @@ def SetLimit(pLimit):
         logger.info("setting new limit to %s Watt",CastToInt(pLimit))
         SetLimit.LastLimit = CastToInt(pLimit)
         SetLimit.LastLimitAck = True
-        if (CastToInt(pLimit) <= GetMinWattFromAllInverters()):
+        min_watt_all_inverters = GetMinWattFromAllInverters()
+        if (CastToInt(pLimit) <= min_watt_all_inverters):
             pLimit = 0 # set only minWatt for every inv.
+            PublishGlobalState("limit", min_watt_all_inverters)
+        else:
+            PublishGlobalState("limit", CastToInt(pLimit))
         for i in range(INVERTER_COUNT):
             if (not AVAILABLE[i]) or (not HOY_BATTERY_GOOD_VOLTAGE[i]):
                 continue
@@ -323,6 +338,7 @@ def SetLimit(pLimit):
 
             LASTLIMITACKNOWLEDGED[i] = True
 
+            PublishInverterState(i, "limit", NewLimit)
             DTU.SetLimit(i, NewLimit)
             if not DTU.WaitForAck(i, SET_LIMIT_TIMEOUT_SECONDS):
                 SetLimit.LastLimitAck = False
@@ -622,6 +638,32 @@ def GetPriorityMode():
             if CONFIG_PROVIDER.get_battery_priority(i) != CONFIG_PROVIDER.get_battery_priority(j):
                 return True
     return False
+
+def PublishConfigState():
+    if MQTT is None:
+        return
+    MQTT.publish_state("on_grid_usage_jump_to_limit_percent", CONFIG_PROVIDER.on_grid_usage_jump_to_limit_percent())
+    MQTT.publish_state("on_grid_feed_fast_limit_decrease", CONFIG_PROVIDER.on_grid_feed_fast_limit_decrease())
+    MQTT.publish_state("powermeter_target_point", CONFIG_PROVIDER.get_powermeter_target_point())
+    MQTT.publish_state("powermeter_max_point", CONFIG_PROVIDER.get_powermeter_max_point())
+    MQTT.publish_state("powermeter_min_point", CONFIG_PROVIDER.get_powermeter_min_point())
+    MQTT.publish_state("powermeter_tolerance", CONFIG_PROVIDER.get_powermeter_tolerance())
+    MQTT.publish_state("inverter_count", INVERTER_COUNT)
+    for i in range(INVERTER_COUNT):
+        MQTT.publish_inverter_state(i, "min_watt_in_percent", CONFIG_PROVIDER.get_min_wattage_in_percent(i))
+        MQTT.publish_inverter_state(i, "normal_watt", CONFIG_PROVIDER.get_normal_wattage(i))
+        MQTT.publish_inverter_state(i, "reduce_watt", CONFIG_PROVIDER.get_reduce_wattage(i))
+        MQTT.publish_inverter_state(i, "battery_priority", CONFIG_PROVIDER.get_battery_priority(i))
+
+def PublishGlobalState(state_name, state_value):
+    if MQTT is None:
+        return
+    MQTT.publish_state(state_name, state_value)
+
+def PublishInverterState(inverter_idx, state_name, state_value):
+    if MQTT is None:
+        return
+    MQTT.publish_inverter_state(inverter_idx, state_name, state_value)
 
 class Powermeter:
     def GetPowermeterWatts(self) -> int:
@@ -1402,16 +1444,26 @@ for i in range(INVERTER_COUNT):
 SLOW_APPROX_LIMIT = CastToInt(GetMaxWattFromAllInverters() * config.getint('COMMON', 'SLOW_APPROX_LIMIT_IN_PERCENT') / 100)
 
 CONFIG_PROVIDER = ConfigFileConfigProvider(config)
+MQTT = None
 if config.has_section("MQTT_CONFIG"):
     broker = config.get("MQTT_CONFIG", "MQTT_BROKER")
     port = config.getint("MQTT_CONFIG", "MQTT_PORT", fallback=1883)
     client_id = config.get("MQTT_CONFIG", "MQTT_CLIENT_ID", fallback="HoymilesZeroExport")
     username = config.get("MQTT_CONFIG", "MQTT_USERNAME", fallback=None)
     password = config.get("MQTT_CONFIG", "MQTT_PASSWORD", fallback=None)
-    set_topic = config.get("MQTT_CONFIG", "MQTT_SET_TOPIC", fallback="zeropower/set")
-    reset_topic = config.get("MQTT_CONFIG", "MQTT_RESET_TOPIC", fallback="zeropower/reset")
-    mqtt_config_provider = MqttConfigProvider(broker, port, client_id, username, password, set_topic, reset_topic)
-    CONFIG_PROVIDER = ConfigProviderChain([mqtt_config_provider, CONFIG_PROVIDER])
+    topic_prefix = config.get("MQTT_CONFIG", "MQTT_SET_TOPIC", fallback="zeropower")
+    log_level_config_value = config.get("MQTT_CONFIG", "MQTT_LOG_LEVEL", fallback=None)
+    mqtt_log_level = logging.getLevelName(log_level_config_value) if log_level_config_value else None
+    MQTT = MqttHandler(broker, port, client_id, username, password, topic_prefix, mqtt_log_level)
+
+    if mqtt_log_level is not None:
+        class MqttLogHandler(logging.Handler):
+            def emit(self, record):
+                MQTT.publish_log_record(record)
+
+        logger.addHandler(MqttLogHandler())
+
+    CONFIG_PROVIDER = ConfigProviderChain([MQTT, CONFIG_PROVIDER])
 
 try:
     logger.info("---Init---")
@@ -1434,6 +1486,7 @@ logger.info("---Start Zero Export---")
 
 while True:
     CONFIG_PROVIDER.update()
+    PublishConfigState()
     on_grid_usage_jump_to_limit_percent = CONFIG_PROVIDER.on_grid_usage_jump_to_limit_percent()
     on_grid_feed_fast_limit_decrease = CONFIG_PROVIDER.on_grid_feed_fast_limit_decrease()    
     powermeter_target_point = CONFIG_PROVIDER.get_powermeter_target_point()

--- a/HoymilesZeroExport_Config.ini
+++ b/HoymilesZeroExport_Config.ini
@@ -238,18 +238,9 @@ AMIS_READER_IP_INTERMEDIATE = xxx.xxx.xxx.xxx
 # MQTT_CLIENT_ID = HoymilesZeroExport
 # MQTT_USERNAME = <optional username>
 # MQTT_PASSWORD = <optional password>
-
-# The script subscribes to the following topics:
-# - zeropower/set/powermeter_target_point: To change the target point of the powermeter
-# - zeropower/set/powermeter_max_point: To change the max point of the powermeter
-# - zeropower/set/powermeter_tolerance: To change the tolerance of the powermeter
-# - zeropower/set/on_grid_usage_jump_to_limit_percent: To change the on grid usage jump to limit percent
-# - zeropower/set/inverter/0/min_watt_in_percent: To change the min watt in percent of the first inverter
-# - zeropower/set/inverter/0/normal_watt: To change the battery normal watt of the first inverter
-# - zeropower/set/inverter/0/reduce_watt: To change the battery reduce watt of the first inverter
-# - zeropower/set/inverter/0/battery_priority: To change the battery priority of the first inverter
-# MQTT_SET_TOPIC = zeropower/set
-# MQTT_RESET_TOPIC = zeropower/reset
+# MQTT_TOPIC_PREFIX = zeropower
+# Set the log level to publish logs to MQTT. Possible values are DEBUG, INFO, WARNING, ERROR, CRITICAL.
+# MQTT_LOG_LEVEL = INFO
 
 [COMMON]
 # Number of Inverters

--- a/README.md
+++ b/README.md
@@ -155,6 +155,39 @@ services:
     command: -c /app/config.ini
 ```
 
+## MQTT
+The script can optionally be controlled via MQTT. To enable this feature, you need to configure the `[MQTT_CONFIG]` section in the configuration file.
+Once configured, the script will listen for incoming MQTT messages on the specified topic and act accordingly.
+- `zeropower/set/powermeter_target_point`: To change the target point of the powermeter
+- `zeropower/set/powermeter_max_point`: To change the max point of the powermeter
+- `zeropower/set/powermeter_min_point`: To change the min point of the powermeter
+- `zeropower/set/powermeter_tolerance`: To change the tolerance of the powermeter
+- `zeropower/set/on_grid_usage_jump_to_limit_percent`: To change the on grid usage jump to limit percent
+- `zeropower/set/on_grid_feed_fast_limit_decrease`: To enable or disable the on grid feed fast limit decrease
+- `zeropower/set/inverter/0/min_watt_in_percent`: To change the min watt in percent of the first inverter
+- `zeropower/set/inverter/0/normal_watt`: To change the battery normal watt of the first inverter
+- `zeropower/set/inverter/0/reduce_watt`: To change the battery reduce watt of the first inverter
+- `zeropower/set/inverter/0/battery_priority`: To change the battery priority of the first inverter
+- `zeropower/set/inverter/<n>/*`: To change the settings of the (n+1)th inverter
+
+To reset a setting to its original value, you can send an empty message to the corresponding topic replacing `set` with `reset`, e.g. `zeropower/reset/powermeter_target_point`.
+
+Additionally, the script will publish the following MQTT messages:
+- `zeropower/status`: The current status of the script. Possible values are `online` and `offline`
+- `zeropower/state/powermeter_target_point`: The current target point of the powermeter
+- `zeropower/state/powermeter_max_point`: The current max point of the powermeter
+- `zeropower/state/powermeter_min_point`: The current min point of the powermeter
+- `zeropower/state/powermeter_tolerance`: The current tolerance of the powermeter
+- `zeropower/state/on_grid_usage_jump_to_limit_percent`: The current on grid usage jump to limit percent
+- `zeropower/state/on_grid_feed_fast_limit_decrease`: The current on grid feed fast limit decrease
+- `zeropower/state/inverter/0/min_watt_in_percent`: The current min watt in percent of the first inverter
+- `zeropower/state/inverter/0/normal_watt`: The current battery normal watt of the first inverter
+- `zeropower/state/inverter/0/reduce_watt`: The current battery reduce watt of the first inverter
+- `zeropower/state/inverter/0/battery_priority`: The current battery priority of the first inverter
+- `zeropower/state/inverter/<n>/*`: The current settings of the (n+1)th inverter
+
+The script can also be configured to publish log messages to MQTT. To enable this feature, you need to set `MQTT_LOG_LEVEL` to `INFO`, which will publish all log messages to the topic `zeropower/log`.
+
 ## Special thanks to:
 - https://github.com/lumapu/ahoy
 - https://github.com/tbnobody/OpenDTU


### PR DESCRIPTION
With this change, the script publishes the following info to the MQTT broker:
- The overall status of the script (`online` or `offline`). Automatically switches to `offline` when the script disconnects from the broker through an LWT
- The state of the current config: This is useful to acknowledge a config update and visualize initial config values in the home automation system
- The overall limit value
- The individual inverter limit values
- All log messages

To support all these MQTT features, I replaced the two topic configs with a single topic prefix config.